### PR TITLE
Don't assume that /tmp exists, use File::Temp instead

### DIFF
--- a/lib/POE/Test/Loops/wheel_sf_unix.pm
+++ b/lib/POE/Test/Loops/wheel_sf_unix.pm
@@ -15,6 +15,7 @@ BEGIN {
 }
 
 use Socket;
+use File::Temp qw(tempfile);
 
 # We can't test_setup(0, "reason") because that calls exit().  And Tk
 # will croak if you call BEGIN { exit() }.  And that croak will cause
@@ -47,7 +48,7 @@ use POE qw(
   Driver::SysRW
 );
 
-my $unix_server_socket = '/tmp/poe-usrv';
+my (undef, $unix_server_socket) = tempfile('poe-usrv-XXXXXX');
 
 ###############################################################################
 # A generic server session.


### PR DESCRIPTION
Some unixy systems don't have /tmp (android, blackberry 10)
which was causing tests in POE to fail.
