### PR TITLE
Try to load Socket::GetAddrInfo 0.22 without :newapi

### DIFF
--- a/lib/POE/Test/Loops/wheel_sf_ipv6.pm
+++ b/lib/POE/Test/Loops/wheel_sf_ipv6.pm
@@ -29,7 +29,8 @@ BEGIN {
 BEGIN {
   my $error;
 
-  eval 'use Socket::GetAddrInfo qw(:newapi getaddrinfo getnameinfo NI_NUMERICHOST NI_NUMERICSERV)';
+  eval 'use Socket::GetAddrInfo 0.22 qw(getaddrinfo getnameinfo NI_NUMERICHOST NI_NUMERICSERV)';
+  eval 'use Socket::GetAddrInfo qw(:newapi getaddrinfo getnameinfo NI_NUMERICHOST NI_NUMERICSERV)' if $@;
   if ($@) {
     $error = "Socket::GetAddrInfo is needed for IPv6 tests";
   }


### PR DESCRIPTION
This test is skipped consistently if Socket::GetAddrInfo 0.22+ is installed, because the `:newapi` import item causes a fatal error now. Added a line to try using Socket::GetAddrInfo 0.22 without `:newapi` first.
