### PR TITLE
Add recommends prereqs for modules used by tests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,12 @@ bugtracker.rt     = 1
 [Prereqs]
 Test::More = 0.95
 
+[Prereqs / Recommends]
+Curses = 0
+IO::Pty = 0
+Socket::GetAddrInfo = 0
+Term::Size = 0
+
 [CheckPrereqsIndexed]
 [Prereqs::MatchInstalled::All]
 exclude = bytes


### PR DESCRIPTION
Some modules are optionally used by tests, by adding them to Recommends prereqs they may get installed if possible to do so.
